### PR TITLE
fix: 設定を `config.json` に移すように変更

### DIFF
--- a/.github/workflows/token.yml
+++ b/.github/workflows/token.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn add -D style-dictionary
 
       - name: run style-dictionary
-        run: yarn style-dictionary build --config ./data/tokens.json
+        run: yarn style-dictionary build
 
       - name: add and commit
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/config.json
+++ b/config.json
@@ -1,0 +1,13 @@
+{
+  "source": ["data/tokens.json"],
+  "platforms": {
+    "scss": {
+      "transformGroup": "scss",
+      "buildPath": "src/styles/",
+      "files": [{
+        "destination": "_variables.scss",
+        "format": "scss/variables"
+      }]
+    }
+  }
+}


### PR DESCRIPTION
`--config`オプションで設定していたのを、 `config.json`ファイルを置くように変更しました。

ローカルで、 `yarn style-dictionary build` で `src/styles/` に吐き出されることを確認しました。