### PR TITLE
レイアウトコンポーネントの追加

### DIFF
--- a/src/@types/yaml.d.ts
+++ b/src/@types/yaml.d.ts
@@ -1,14 +1,14 @@
 import type { ParseOptions, DocumentOptions, SchemaOptions, ToJSOptions } from "yaml";
 import type { Reviver } from "yaml/dist/doc/applyReviver";
-import type { RField } from "../models/type";
+import type { Fields } from "../models";
 
 declare module "yaml" {
-  function parse<T extends RField>(
+  function parse<T extends Fields>(
     // eslint-disable-next-line unicorn/prevent-abbreviations
     src: string,
     options?: ParseOptions & DocumentOptions & SchemaOptions & ToJSOptions,
   ): T;
-  function parse<T extends RField>(
+  function parse<T extends Fields>(
     // eslint-disable-next-line unicorn/prevent-abbreviations
     src: string,
     reviver: Reviver,

--- a/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
+++ b/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) templates/layout snap shot 1`] = `
+<div>
+  <div
+    class="css-1m2qlh2-LayoutBox exwm4bw2"
+  >
+    <div
+      class="css-12mee5r-MainBox exwm4bw1"
+    >
+      <div
+        class="css-1vrhv8u-Main exwm4bw0"
+      >
+        <main />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
+++ b/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`(components) templates/layout snap shot 1`] = `
     >
       <div
         class="css-1vrhv8u-Main exwm4bw0"
+        role="main"
       >
         <main />
       </div>

--- a/src/components/templates/layout/index.tsx
+++ b/src/components/templates/layout/index.tsx
@@ -11,7 +11,7 @@ const Main = tw.div`mr-auto ml-64.75`;
 const Layout: React.FC<LayoutProperties> = ({ children, ...rest }) => (
   <LayoutBox {...rest}>
     <MainBox>
-      <Main>{children}</Main>
+      <Main role={"main"}>{children}</Main>
     </MainBox>
   </LayoutBox>
 );

--- a/src/components/templates/layout/index.tsx
+++ b/src/components/templates/layout/index.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import tw from "twin.macro";
+import type { LayoutProperties } from "../../../models";
+
+const LayoutBox = tw.div`min-h-screen bg-[#211A1A]`;
+
+const MainBox = tw.div`flex flex-col items-center`;
+
+const Main = tw.div`mr-auto ml-64.75`;
+
+const Layout: React.FC<LayoutProperties> = ({ children, ...rest }) => (
+  <LayoutBox {...rest}>
+    <MainBox>
+      <Main>{children}</Main>
+    </MainBox>
+  </LayoutBox>
+);
+
+export { Layout };

--- a/src/components/templates/layout/layout.stories.tsx
+++ b/src/components/templates/layout/layout.stories.tsx
@@ -1,0 +1,13 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { Layout } from ".";
+
+type T = typeof Layout
+type Story = ComponentStoryObj<T>
+
+const data = {
+  node: <main />
+}
+
+export default { args: { children: data.node }, component: Layout, title: "Layout" } as ComponentMeta<T>;
+
+export const Default: Story = {};

--- a/src/components/templates/layout/layout.stories.tsx
+++ b/src/components/templates/layout/layout.stories.tsx
@@ -1,12 +1,12 @@
 import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
 import { Layout } from ".";
 
-type T = typeof Layout
-type Story = ComponentStoryObj<T>
+type T = typeof Layout;
+type Story = ComponentStoryObj<T>;
 
 const data = {
-  node: <main />
-}
+  node: <main />,
+};
 
 export default { args: { children: data.node }, component: Layout, title: "Layout" } as ComponentMeta<T>;
 

--- a/src/components/templates/layout/layout.test.tsx
+++ b/src/components/templates/layout/layout.test.tsx
@@ -1,0 +1,17 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./layout.stories";
+
+const { Default } = composeStories(stories);
+
+describe("(components) templates/layout", () => {
+  test("to be templates", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeTemplate();
+  });
+  test("snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+})

--- a/src/components/templates/layout/layout.test.tsx
+++ b/src/components/templates/layout/layout.test.tsx
@@ -14,4 +14,4 @@ describe("(components) templates/layout", () => {
     const { container } = render(<Default />);
     expect(container).toMatchSnapshot();
   });
-})
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,3 +1,5 @@
+import React from "react";
+
 export type _Field = {
   __typename: FieldsKey;
   path: string;
@@ -22,3 +24,7 @@ type _Test = {
 };
 
 export type Tests = Array<_Test>;
+
+export type LayoutProperties = React.ComponentProps<React.ReactHTML["div"]> & {
+  children: React.ReactNode;
+};

--- a/src/utils/api/api.test.ts
+++ b/src/utils/api/api.test.ts
@@ -1,4 +1,4 @@
-import type { Tests } from "../../models/type";
+import type { Tests } from "../../models";
 import { readYaml, getDataByField } from ".";
 
 describe("(utils)API test", () => {

--- a/src/utils/api/index.ts
+++ b/src/utils/api/index.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { match, P } from "ts-pattern";
 import { parse } from "yaml";
-import type { _Field, Fields, RYaml, RDataByField, Sponsors, Tests } from "../../models/type";
+import type { _Field, Fields, RYaml, RDataByField, Sponsors, Tests } from "../../models";
 
 const getAssetsDirectory = () => join(process.cwd(), "assets");
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,13 @@ module.exports = {
   darkMode: "class",
   plugins: [],
   content: ["./src/**/*.{ts,tsx}"],
-  theme: {},
+  theme: {
+    extend: {
+      margin: {
+        64.75: "16.1875rem",
+      },
+    },
+  },
   variants: {
     extend: {},
   },


### PR DESCRIPTION
# 📝 what

- レイアウトコンポーネントの追加

# 😎 why

- 共通のレイアウトなので作成した。
- NextJSのRFCに上がっているgetLayoutを使おうと思ったがスタック的に不必要だったのでお見送り
- 一応最低限のa11yは保証されているがe2eテストを導入した後に修正する可能性あり

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

close #110 
