### PR TITLE
著作者がすべて @re-taro になっていたものを、 @suzuka-kosen-festa に変更

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Rintaro Itokawa
+Copyright (c) 2022 suzuka-kosen-festa Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,21 +1,14 @@
 {
-  "name": "next-typescript-template",
+  "name": "webpage",
   "version": "1.0.0",
-  "description": "Template for personal Next projects",
-  "keywords": [
-    "next",
-    "typescript",
-    "template"
-  ],
+  "description": "第57回鈴鹿高専祭 公式HP",
   "repository": {
     "type": "git",
-    "url": "https://github.com/re-taro/next-typescript-template"
+    "url": "https://github.com/suzuka-kosen-festa/2022-HP"
   },
   "license": "MIT",
   "author": {
-    "name": "Rintaro Itokawa",
-    "email": "me@re-taro.dev",
-    "url": "https://re-taro.dev"
+    "name": "suzuka-kosen-festa"
   },
   "scripts": {
     "dev": "next dev",

--- a/src/components/atoms/anchor-text/__snapshots__/anchor-text.test.tsx.snap
+++ b/src/components/atoms/anchor-text/__snapshots__/anchor-text.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`(components) atoms/anchor take snap shot 1`] = `
 <div>
   <a
-    class="twin-1w1mmlr-AnchorText e1n95ynn0"
+    class="twin-1w1mmlr-AnchorText ey6ijqd0"
     href="#"
     role="link"
   >

--- a/yarn.lock
+++ b/yarn.lock
@@ -15817,66 +15817,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next-typescript-template@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "next-typescript-template@workspace:."
-  dependencies:
-    "@babel/core": 7.18.10
-    "@babel/preset-env": 7.18.10
-    "@babel/preset-react": 7.18.6
-    "@emotion/babel-plugin": 11.10.0
-    "@emotion/babel-plugin-jsx-pragmatic": 0.2.0
-    "@emotion/babel-preset-css-prop": 11.10.0
-    "@emotion/cache": 11.10.1
-    "@emotion/react": 11.10.0
-    "@emotion/serialize": 1.1.0
-    "@emotion/styled": 11.10.0
-    "@mdx-js/react": 2.1.2
-    "@storybook/addon-a11y": 6.5.10
-    "@storybook/addon-actions": 6.5.10
-    "@storybook/addon-docs": 6.5.10
-    "@storybook/addon-essentials": 6.5.10
-    "@storybook/addon-interactions": 6.5.10
-    "@storybook/addon-links": 6.5.10
-    "@storybook/addon-postcss": 2.0.0
-    "@storybook/builder-webpack5": 6.5.10
-    "@storybook/cli": 6.5.10
-    "@storybook/manager-webpack5": 6.5.10
-    "@storybook/react": 6.5.10
-    "@storybook/testing-library": 0.0.13
-    "@storybook/testing-react": 1.3.0
-    "@testing-library/jest-dom": 5.16.5
-    "@testing-library/react": 13.3.0
-    "@testing-library/user-event": 14.4.2
-    "@types/node": 17.0.21
-    "@types/react": 18.0.17
-    "@types/react-dom": 18.0.6
-    "@types/tailwindcss": 3.0.11
-    autoprefixer: 10.4.8
-    babel-jest: 28.1.3
-    babel-loader: 8.2.5
-    chromatic: 6.7.3
-    cross-env: 7.0.3
-    eslint: 8.21.0
-    eslint-config-re-taro: 1.1.3
-    eslint-plugin-storybook: 0.6.3
-    jest: 28.1.3
-    jest-environment-jsdom: 28.1.3
-    next: 12.2.4
-    postcss: 8.4.16
-    prettier: 2.7.1
-    react: 18.2.0
-    react-dom: 18.2.0
-    style-dictionary: 3.7.1
-    tailwindcss: 3.1.8
-    ts-pattern: 4.0.5
-    twin.macro: 2.8.2
-    typescript: 4.7.4
-    webpack: 5.74.0
-    yaml: 2.1.1
-  languageName: unknown
-  linkType: soft
-
 "next@npm:12.2.4":
   version: 12.2.4
   resolution: "next@npm:12.2.4"
@@ -21100,6 +21040,66 @@ __metadata:
   checksum: aa434a241bad6176b68e1bf0feb1972da4dcbf27cb3d94ae24f6eb31acc37dceb9c4aae55e068edca75817bfe91f13cd20b023ac55d9b1b2f8b66a4037c9468f
   languageName: node
   linkType: hard
+
+"webpage@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "webpage@workspace:."
+  dependencies:
+    "@babel/core": 7.18.10
+    "@babel/preset-env": 7.18.10
+    "@babel/preset-react": 7.18.6
+    "@emotion/babel-plugin": 11.10.0
+    "@emotion/babel-plugin-jsx-pragmatic": 0.2.0
+    "@emotion/babel-preset-css-prop": 11.10.0
+    "@emotion/cache": 11.10.1
+    "@emotion/react": 11.10.0
+    "@emotion/serialize": 1.1.0
+    "@emotion/styled": 11.10.0
+    "@mdx-js/react": 2.1.2
+    "@storybook/addon-a11y": 6.5.10
+    "@storybook/addon-actions": 6.5.10
+    "@storybook/addon-docs": 6.5.10
+    "@storybook/addon-essentials": 6.5.10
+    "@storybook/addon-interactions": 6.5.10
+    "@storybook/addon-links": 6.5.10
+    "@storybook/addon-postcss": 2.0.0
+    "@storybook/builder-webpack5": 6.5.10
+    "@storybook/cli": 6.5.10
+    "@storybook/manager-webpack5": 6.5.10
+    "@storybook/react": 6.5.10
+    "@storybook/testing-library": 0.0.13
+    "@storybook/testing-react": 1.3.0
+    "@testing-library/jest-dom": 5.16.5
+    "@testing-library/react": 13.3.0
+    "@testing-library/user-event": 14.4.2
+    "@types/node": 17.0.21
+    "@types/react": 18.0.17
+    "@types/react-dom": 18.0.6
+    "@types/tailwindcss": 3.0.11
+    autoprefixer: 10.4.8
+    babel-jest: 28.1.3
+    babel-loader: 8.2.5
+    chromatic: 6.7.3
+    cross-env: 7.0.3
+    eslint: 8.21.0
+    eslint-config-re-taro: 1.1.3
+    eslint-plugin-storybook: 0.6.3
+    jest: 28.1.3
+    jest-environment-jsdom: 28.1.3
+    next: 12.2.4
+    postcss: 8.4.16
+    prettier: 2.7.1
+    react: 18.2.0
+    react-dom: 18.2.0
+    style-dictionary: 3.7.1
+    tailwindcss: 3.1.8
+    ts-pattern: 4.0.5
+    twin.macro: 2.8.2
+    typescript: 4.7.4
+    webpack: 5.74.0
+    yaml: 2.1.1
+  languageName: unknown
+  linkType: soft
 
 "whatwg-encoding@npm:^2.0.0":
   version: 2.0.0


### PR DESCRIPTION
# 📝 what

- 著作者がすべて @re-taro になっていたものを、 @suzuka-kosen-festa に変更

# 😎 why

- 私以外に、 @Sansai-snct も実装に関わっているため
- 個人制作物ではなく、高専祭実行委員会のものだから

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

close #126 
