### PR TITLE
headingコンポーネントを実装した

### DIFF
--- a/src/components/atoms/heading/__snapshots__/heading.test.tsx.snap
+++ b/src/components/atoms/heading/__snapshots__/heading.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) atoms/heading take snap shot 1`] = `
+<div>
+  <h1
+    class="twin-1bh7ayn-Heading ebaq0s80"
+  >
+    This is test
+  </h1>
+</div>
+`;

--- a/src/components/atoms/heading/heading.stories.tsx
+++ b/src/components/atoms/heading/heading.stories.tsx
@@ -1,0 +1,13 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { Heading } from ".";
+
+type T = typeof Heading;
+type Story = ComponentStoryObj<T>;
+
+const data = {
+  sentence: "This is test",
+};
+
+export default { args: { children: data.sentence }, component: Heading } as ComponentMeta<T>;
+
+export const Default: Story = {};

--- a/src/components/atoms/heading/heading.test.tsx
+++ b/src/components/atoms/heading/heading.test.tsx
@@ -6,8 +6,8 @@ import * as stories from "./heading.stories";
 const { Default } = composeStories(stories);
 
 const options = {
-  name: "This is test"
-}
+  name: "This is test",
+};
 
 describe("(components) atoms/heading", () => {
   test("to be atoms", () => {
@@ -15,9 +15,9 @@ describe("(components) atoms/heading", () => {
     expect(container).toBeAtom();
   });
   test("to be [role=heading]", () => {
-    const { getByRole } = render(<Default />)
-    expect(getByRole("heading", options))
-  })
+    const { getByRole } = render(<Default />);
+    expect(getByRole("heading", options));
+  });
   test("take snap shot", () => {
     const { container } = render(<Default />);
     expect(container).toMatchSnapshot();

--- a/src/components/atoms/heading/heading.test.tsx
+++ b/src/components/atoms/heading/heading.test.tsx
@@ -1,0 +1,25 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./heading.stories";
+
+const { Default } = composeStories(stories);
+
+const options = {
+  name: "This is test"
+}
+
+describe("(components) atoms/heading", () => {
+  test("to be atoms", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("to be [role=heading]", () => {
+    const { getByRole } = render(<Default />)
+    expect(getByRole("heading", options))
+  })
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/atoms/heading/index.tsx
+++ b/src/components/atoms/heading/index.tsx
@@ -1,0 +1,5 @@
+import tw from "twin.macro"
+
+const Heading = tw.h1`font-zen text-white text-[calc(10px + 26 * ((100vw - 378px) / 1134))] select-none`
+
+export { Heading }

--- a/src/components/atoms/heading/index.tsx
+++ b/src/components/atoms/heading/index.tsx
@@ -1,5 +1,5 @@
-import tw from "twin.macro"
+import tw from "twin.macro";
 
-const Heading = tw.h1`font-zen text-white text-[calc(10px + 26 * ((100vw - 378px) / 1134))] select-none`
+const Heading = tw.h1`font-zen text-white text-[calc(10px + 26 * ((100vw - 378px) / 1134))] select-none`;
 
-export { Heading }
+export { Heading };


### PR DESCRIPTION
# 📝 what

- headingコンポーネントを実装した

# 😎 why

- 使いまわし可能なheadingコンポーネントが必要だった

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

Fixes #121 
