### PR TITLE
mapセクションの実装

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -35,3 +35,5 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+        env:
+          GOOGLE_MAP_API_KEY: ${{ secrets.GOOGLE_MAP_API_KEY }}

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.3.0",
     "@testing-library/user-event": "14.4.3",
+    "@types/google.maps": "^3.49.2",
     "@types/node": "17.0.21",
     "@types/react": "18.0.17",
     "@types/react-dom": "18.0.6",

--- a/src/components/molecules/map/__snapshots__/map.test.tsx.snap
+++ b/src/components/molecules/map/__snapshots__/map.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) molecules/map take snap shot 1`] = `
+<div>
+  <figure
+    class="twin-oubtkh-MapContainer e105lmtd1"
+  >
+    <div
+      class="twin-1xoy3t5-MapWrapper e105lmtd0"
+    >
+      <iframe
+        allowfullscreen=""
+        class="twin-u695ll-Map"
+        id="map"
+        loading="lazy"
+        referrerpolicy="no-referrer-when-downgrade"
+        role="document"
+        src="https://www.google.com/maps/embed/v1/view?key=&center=34.85167124241317%2C136.58132309784355&zoom=15"
+        title="鈴鹿工業高等専門学校の地図"
+      />
+    </div>
+  </figure>
+</div>
+`;

--- a/src/components/molecules/map/index.tsx
+++ b/src/components/molecules/map/index.tsx
@@ -4,9 +4,9 @@ import type { MapProperties } from "../../../models";
 
 const GOOGLE_MAP_API_KEY = process.env.GOOGLE_MAP_API_KEY || "";
 
-const MapContainer = tw.figure`w-full lg:w-6/12`
+const MapContainer = tw.figure`w-full lg:w-6/12`;
 
-const MapWrapper = tw.div`relative w-full h-0 pt-[100%] lg:pt-[56.25%]`
+const MapWrapper = tw.div`relative w-full h-0 pt-[100%] lg:pt-[56.25%]`;
 
 const Map: React.FC<MapProperties> = ({ center, title, zoom, ...rest }) => (
   <MapContainer>

--- a/src/components/molecules/map/index.tsx
+++ b/src/components/molecules/map/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import tw from "twin.macro";
+import type { MapProperties } from "../../../models";
+
+const GOOGLE_MAP_API_KEY = process.env.GOOGLE_MAP_API_KEY || "";
+
+const MapContainer = tw.figure`w-full lg:w-6/12`
+
+const MapWrapper = tw.div`relative w-full h-0 pt-[100%] lg:pt-[56.25%]`
+
+const Map: React.FC<MapProperties> = ({ center, title, zoom, ...rest }) => (
+  <MapContainer>
+    <MapWrapper>
+      <iframe
+        id={"map"}
+        title={`${title}の地図`}
+        role={"document"}
+        src={`https://www.google.com/maps/embed/v1/view?key=${GOOGLE_MAP_API_KEY}&center=${center.lat}%2C${center.lng}&zoom=${zoom}`}
+        loading={"lazy"}
+        referrerPolicy={"no-referrer-when-downgrade"}
+        css={tw`absolute top-0 left-0 w-full h-full`}
+        allowFullScreen={true}
+        {...rest}
+      ></iframe>
+    </MapWrapper>
+  </MapContainer>
+);
+
+export { Map };

--- a/src/components/molecules/map/map.stories.tsx
+++ b/src/components/molecules/map/map.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
-import { Map } from "."
+import { Map } from ".";
 
 type T = typeof Map;
 type Story = ComponentStoryObj<T>;
@@ -10,9 +10,12 @@ const data = {
     lng: 136.581_323_097_843_55,
   },
   title: "鈴鹿工業高等専門学校",
-  zoom: 15
-}
+  zoom: 15,
+};
 
-export default { args: { center: data.center, title: data.title, zoom: data.zoom }, component: Map } as ComponentMeta<T>;
+export default {
+  args: { center: data.center, title: data.title, zoom: data.zoom },
+  component: Map,
+} as ComponentMeta<T>;
 
 export const Default: Story = {};

--- a/src/components/molecules/map/map.stories.tsx
+++ b/src/components/molecules/map/map.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { Map } from "."
+
+type T = typeof Map;
+type Story = ComponentStoryObj<T>;
+
+const data = {
+  center: {
+    lat: 34.851_671_242_413_17,
+    lng: 136.581_323_097_843_55,
+  },
+  title: "鈴鹿工業高等専門学校",
+  zoom: 15
+}
+
+export default { args: { center: data.center, title: data.title, zoom: data.zoom }, component: Map } as ComponentMeta<T>;
+
+export const Default: Story = {};

--- a/src/components/molecules/map/map.test.tsx
+++ b/src/components/molecules/map/map.test.tsx
@@ -1,0 +1,33 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./map.stories";
+
+const { Default } = composeStories(stories);
+
+const figureoptions = {
+  name: ""
+}
+
+const documentoptions = {
+  name: "鈴鹿工業高等専門学校の地図"
+}
+
+describe("(components) molecules/map", () => {
+  test("to be molecules", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("to be [role=figure]", () => {
+    const { getByRole } = render(<Default />);
+    expect(getByRole("figure", figureoptions))
+  })
+  test("to be [role=document]", () => {
+    const { getByRole } = render(<Default />)
+    expect(getByRole("document", documentoptions))
+  })
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/map/map.test.tsx
+++ b/src/components/molecules/map/map.test.tsx
@@ -6,12 +6,12 @@ import * as stories from "./map.stories";
 const { Default } = composeStories(stories);
 
 const figureoptions = {
-  name: ""
-}
+  name: "",
+};
 
 const documentoptions = {
-  name: "鈴鹿工業高等専門学校の地図"
-}
+  name: "鈴鹿工業高等専門学校の地図",
+};
 
 describe("(components) molecules/map", () => {
   test("to be molecules", () => {
@@ -20,12 +20,12 @@ describe("(components) molecules/map", () => {
   });
   test("to be [role=figure]", () => {
     const { getByRole } = render(<Default />);
-    expect(getByRole("figure", figureoptions))
-  })
+    expect(getByRole("figure", figureoptions));
+  });
   test("to be [role=document]", () => {
-    const { getByRole } = render(<Default />)
-    expect(getByRole("document", documentoptions))
-  })
+    const { getByRole } = render(<Default />);
+    expect(getByRole("document", documentoptions));
+  });
   test("take snap shot", () => {
     const { container } = render(<Default />);
     expect(container).toMatchSnapshot();

--- a/src/components/organisms/map-section/__snapshots__/map-section.test.tsx.snap
+++ b/src/components/organisms/map-section/__snapshots__/map-section.test.tsx.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) organisms/map-section take snap shot 1`] = `
+<div>
+  <section
+    aria-label="アクセス"
+    class="twin-1xd1333-MapSectionContainer eo5dcy1"
+  >
+    <h1
+      class="twin-1bh7ayn-Heading ebaq0s80"
+    >
+      アクセス
+    </h1>
+    <div
+      class="twin-takigz-MapBox eo5dcy0"
+    >
+      <p
+        class="twin-1eur3k6-Text-MapSection epv4mo00"
+      >
+        〒
+        510-0294 三重県鈴鹿市白子町
+近鉄白子駅から徒歩約30分
+三重交通バス東旭が丘3丁目から徒歩約7分
+      </p>
+      <figure
+        class="twin-oubtkh-MapContainer e105lmtd1"
+      >
+        <div
+          class="twin-1xoy3t5-MapWrapper e105lmtd0"
+        >
+          <iframe
+            allowfullscreen=""
+            class="twin-u695ll-Map"
+            id="map"
+            loading="lazy"
+            referrerpolicy="no-referrer-when-downgrade"
+            role="document"
+            src="https://www.google.com/maps/embed/v1/view?key=&center=34.85167124241317%2C136.58132309784355&zoom=15"
+            title="鈴鹿工業高等専門学校の地図"
+          />
+        </div>
+      </figure>
+    </div>
+  </section>
+</div>
+`;

--- a/src/components/organisms/map-section/index.tsx
+++ b/src/components/organisms/map-section/index.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import tw from "twin.macro";
+import type { MapSectionProperties } from "../../../models";
+import { Heading } from "../../atoms/heading";
+import { Text } from "../../atoms/text";
+import { Map } from "../../molecules/map";
+
+const MapSectionContainer = tw.section`flex flex-col space-y-[calc(200vw / 63)]`;
+
+const MapBox = tw.div`flex flex-col space-y-[calc(200vw / 63)] lg:flex-row-reverse lg:space-x-[calc(800vw / 189)] lg:space-y-0 lg:space-x-reverse justify-end`;
+
+const MapSection: React.FC<MapSectionProperties> = ({ center, children, label, title, zoom, ...rest }) => (
+  <MapSectionContainer aria-label={"アクセス"} {...rest}>
+    <Heading>{title}</Heading>
+    <MapBox>
+      <Text css={tw`whitespace-pre-wrap`}>&#12306;{children}</Text>
+      <Map center={center} title={label} zoom={zoom} />
+    </MapBox>
+  </MapSectionContainer>
+);
+
+export { MapSection };

--- a/src/components/organisms/map-section/map-section.stories.tsx
+++ b/src/components/organisms/map-section/map-section.stories.tsx
@@ -1,0 +1,23 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { MapSection } from ".";
+
+type T = typeof MapSection;
+type Story = ComponentStoryObj<T>;
+
+const data = {
+  center: {
+    lat: 34.851_671_242_413_17,
+    lng: 136.581_323_097_843_55,
+  },
+  children: `510-0294 三重県鈴鹿市白子町\n近鉄白子駅から徒歩約30分\n三重交通バス東旭が丘3丁目から徒歩約7分`,
+  label: "鈴鹿工業高等専門学校",
+  title: "アクセス",
+  zoom: 15,
+};
+
+export default {
+  args: { center: data.center, children: data.children, label: data.label, title: data.title, zoom: data.zoom },
+  component: MapSection,
+} as ComponentMeta<T>;
+
+export const Default: Story = {};

--- a/src/components/organisms/map-section/map-section.test.tsx
+++ b/src/components/organisms/map-section/map-section.test.tsx
@@ -1,0 +1,25 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./map-section.stories"
+
+const { Default } = composeStories(stories);
+
+const regionoptions = {
+  name: "アクセス"
+}
+
+describe("(components) organisms/map-section", () => {
+  test("to be organisms", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("to be [role=region]", () => {
+    const { getByRole } = render(<Default />)
+    expect(getByRole("region", regionoptions))
+  })
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/map-section/map-section.test.tsx
+++ b/src/components/organisms/map-section/map-section.test.tsx
@@ -1,13 +1,13 @@
 import { composeStories } from "@storybook/testing-react";
 import "@testing-library/jest-dom";
 import { render } from "@testing-library/react";
-import * as stories from "./map-section.stories"
+import * as stories from "./map-section.stories";
 
 const { Default } = composeStories(stories);
 
 const regionoptions = {
-  name: "アクセス"
-}
+  name: "アクセス",
+};
 
 describe("(components) organisms/map-section", () => {
   test("to be organisms", () => {
@@ -15,9 +15,9 @@ describe("(components) organisms/map-section", () => {
     expect(container).toBeOrganism();
   });
   test("to be [role=region]", () => {
-    const { getByRole } = render(<Default />)
-    expect(getByRole("region", regionoptions))
-  })
+    const { getByRole } = render(<Default />);
+    expect(getByRole("region", regionoptions));
+  });
   test("take snap shot", () => {
     const { container } = render(<Default />);
     expect(container).toMatchSnapshot();

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -44,3 +44,9 @@ export type SeoProperties = {
   description: string;
   pageRelPath?: string;
 };
+
+export type MapProperties = React.ComponentProps<React.ReactHTML["iframe"]> & {
+  center: google.maps.LatLngLiteral;
+  title: string;
+  zoom: number;
+};

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -35,9 +35,7 @@ export type ButtonProperties<T extends AnyComponent> = React.PropsWithChildren<
   }
 >;
 
-export type LayoutProperties = React.ComponentProps<React.ReactHTML["div"]> & {
-  children: React.ReactNode;
-};
+export type LayoutProperties = React.ComponentProps<React.ReactHTML["div"]>;
 
 export type SeoProperties = {
   title: string;
@@ -45,8 +43,15 @@ export type SeoProperties = {
   pageRelPath?: string;
 };
 
-export type MapProperties = React.ComponentProps<React.ReactHTML["iframe"]> & {
+export type MapProperties = Omit<React.ComponentProps<React.ReactHTML["iframe"]>, "children"> & {
   center: google.maps.LatLngLiteral;
   title: string;
   zoom: number;
 };
+
+export type MapSectionProperties = Omit<React.ComponentProps<React.ReactHTML["section"]>, "children"> &
+  Omit<MapProperties, "title" | "children"> & {
+    title: string;
+    label: string;
+    children: string;
+  };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -35,7 +35,9 @@ export type ButtonProperties<T extends AnyComponent> = React.PropsWithChildren<
   }
 >;
 
-export type LayoutProperties = React.ComponentProps<React.ReactHTML["div"]>;
+export type LayoutProperties = React.ComponentProps<React.ReactHTML["div"]> & {
+  children: React.ReactNode;
+};
 
 export type SeoProperties = {
   title: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5939,6 +5939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/google.maps@npm:^3.49.2":
+  version: 3.49.2
+  resolution: "@types/google.maps@npm:3.49.2"
+  checksum: ca2cb7842dfbc10551b5a33a052bd1c90dab21c13d5632601d87bc908064516a3f90b0b7eb517ce1024ea98734e490e2a90028c5534c52a82ceffb2e1b241fc9
+  languageName: node
+  linkType: hard
+
 "@types/graceful-fs@npm:^4.1.2, @types/graceful-fs@npm:^4.1.3":
   version: 4.1.5
   resolution: "@types/graceful-fs@npm:4.1.5"
@@ -21072,6 +21079,7 @@ __metadata:
     "@testing-library/jest-dom": 5.16.5
     "@testing-library/react": 13.3.0
     "@testing-library/user-event": 14.4.3
+    "@types/google.maps": ^3.49.2
     "@types/node": 17.0.21
     "@types/react": 18.0.17
     "@types/react-dom": 18.0.6


### PR DESCRIPTION
# 📝 what

- mapセクションの実装
  - mapコンポーネントを実装

# 😎 why

- 高専の所在地を表示する必要があった

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

Close #64 
