### PR TITLE
今年のテーマ「Re:ROAD」についてのセクションの実装

### DIFF
--- a/src/components/organisms/festa-section/__snapshots__/festa-section.test.tsx.snap
+++ b/src/components/organisms/festa-section/__snapshots__/festa-section.test.tsx.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) organisms/festa-section take snap shot 1`] = `
+<div>
+  <section
+    aria-label="今年のテーマ「Re:ROAD」について"
+    class="twin-3zsgd5-FestaSectionContainer efthwpx0"
+  >
+    <h1
+      class="twin-f7kb4u-Heading ebaq0s80"
+    >
+      今年のテーマ「Re:ROAD」について
+    </h1>
+    <p
+      class="twin-dcmtlm-Text-FestaSection epv4mo00"
+    >
+      第57回鈴鹿高専祭、テーマは「Re:ROAD」
+今回のテーマ「Re:ROAD」には「道（Road）」を創り直す（Re）という意味と、「弾をこめる・再補填する（Reload）」という意味を使い、「今年の準備をする」「来年以降、これから先のための高専祭を行う」という想いが込められています。
+
+2019年を最後に鈴鹿高専祭は行われていません。
+そのため過去のデータもあまり残っておらず本当に1から、いや0からのスタートです。
+まだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。
+    </p>
+  </section>
+</div>
+`;

--- a/src/components/organisms/festa-section/festa-section.stories.tsx
+++ b/src/components/organisms/festa-section/festa-section.stories.tsx
@@ -1,14 +1,15 @@
 import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
 import { FestaSection } from ".";
 
-type T = typeof FestaSection
-type Story = ComponentStoryObj<T>
+type T = typeof FestaSection;
+type Story = ComponentStoryObj<T>;
 
 const data = {
-  children: "第57回鈴鹿高専祭、テーマは「Re:ROAD」\n今回のテーマ「Re:ROAD」には「道（Road）」を創り直す（Re）という意味と、「弾をこめる・再補填する（Reload）」という意味を使い、「今年の準備をする」「来年以降、これから先のための高専祭を行う」という想いが込められています。\n\n2019年を最後に鈴鹿高専祭は行われていません。\nそのため過去のデータもあまり残っておらず本当に1から、いや0からのスタートです。\nまだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。",
-  title: "今年のテーマ「Re:ROAD」について"
-}
+  children:
+    "第57回鈴鹿高専祭、テーマは「Re:ROAD」\n今回のテーマ「Re:ROAD」には「道（Road）」を創り直す（Re）という意味と、「弾をこめる・再補填する（Reload）」という意味を使い、「今年の準備をする」「来年以降、これから先のための高専祭を行う」という想いが込められています。\n\n2019年を最後に鈴鹿高専祭は行われていません。\nそのため過去のデータもあまり残っておらず本当に1から、いや0からのスタートです。\nまだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。",
+  title: "今年のテーマ「Re:ROAD」について",
+};
 
-export default { args: { children: data.children, title: data.title }, component: FestaSection } as ComponentMeta<T>
+export default { args: { children: data.children, title: data.title }, component: FestaSection } as ComponentMeta<T>;
 
-export const Default: Story = {}
+export const Default: Story = {};

--- a/src/components/organisms/festa-section/festa-section.stories.tsx
+++ b/src/components/organisms/festa-section/festa-section.stories.tsx
@@ -1,0 +1,14 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { FestaSection } from ".";
+
+type T = typeof FestaSection
+type Story = ComponentStoryObj<T>
+
+const data = {
+  children: "第57回鈴鹿高専祭、テーマは「Re:ROAD」\n今回のテーマ「Re:ROAD」には「道（Road）」を創り直す（Re）という意味と、「弾をこめる・再補填する（Reload）」という意味を使い、「今年の準備をする」「来年以降、これから先のための高専祭を行う」という想いが込められています。\n\n2019年を最後に鈴鹿高専祭は行われていません。\nそのため過去のデータもあまり残っておらず本当に1から、いや0からのスタートです。\nまだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。",
+  title: "今年のテーマ「Re:ROAD」について"
+}
+
+export default { args: { children: data.children, title: data.title }, component: FestaSection } as ComponentMeta<T>
+
+export const Default: Story = {}

--- a/src/components/organisms/festa-section/festa-section.test.tsx
+++ b/src/components/organisms/festa-section/festa-section.test.tsx
@@ -1,0 +1,25 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./festa-section.stories";
+
+const { Default } = composeStories(stories);
+
+const options = {
+  name: "今年のテーマ「Re:ROAD」について",
+};
+
+describe("(components) organisms/festa-section", () => {
+  test("to be organisms", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("to be [role=region]", () => {
+    const { getByRole } = render(<Default />);
+    expect(getByRole("region", options));
+  });
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/organisms/festa-section/index.tsx
+++ b/src/components/organisms/festa-section/index.tsx
@@ -1,16 +1,16 @@
 import React from "react";
-import tw from "twin.macro"
+import tw from "twin.macro";
 import type { FestaSectionProperties } from "../../../models";
 import { Heading } from "../../atoms/heading";
 import { Text } from "../../atoms/text";
 
-const FestaSectionContainer = tw.section`flex flex-col space-y-[calc(200vw / 63)]`
+const FestaSectionContainer = tw.section`flex flex-col space-y-[calc(200vw / 63)]`;
 
-const FestaSection: React.FC<FestaSectionProperties> = ({ children, title, ...rest} ) => (
+const FestaSection: React.FC<FestaSectionProperties> = ({ children, title, ...rest }) => (
   <FestaSectionContainer aria-label={"今年のテーマ「Re:ROAD」について"} {...rest}>
     <Heading>{title}</Heading>
     <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
   </FestaSectionContainer>
-)
+);
 
-export { FestaSection }
+export { FestaSection };

--- a/src/components/organisms/festa-section/index.tsx
+++ b/src/components/organisms/festa-section/index.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import tw from "twin.macro"
+import type { FestaSectionProperties } from "../../../models";
+import { Heading } from "../../atoms/heading";
+import { Text } from "../../atoms/text";
+
+const FestaSectionContainer = tw.section`flex flex-col space-y-[calc(200vw / 63)]`
+
+const FestaSection: React.FC<FestaSectionProperties> = ({ children, title, ...rest} ) => (
+  <FestaSectionContainer aria-label={"今年のテーマ「Re:ROAD」について"} {...rest}>
+    <Heading>{title}</Heading>
+    <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
+  </FestaSectionContainer>
+)
+
+export { FestaSection }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -67,3 +67,8 @@ export type HeroSectionProperties = Omit<React.ComponentProps<React.ReactHTML["s
   date: string;
   title: string;
 };
+
+export type FestaSectionProperties = Omit<React.ComponentProps<React.ReactHTML["section"]>, "children"> & {
+  title: string;
+  children: string;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -71,4 +71,4 @@ export type HeroSectionProperties = Omit<React.ComponentProps<React.ReactHTML["s
 export type FestaSectionProperties = Omit<React.ComponentProps<React.ReactHTML["section"]>, "children"> & {
   title: string;
   children: string;
-}
+};


### PR DESCRIPTION
# 📝 what

- 今年のテーマ「Re:ROAD」についてのセクションの実装

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

Close #139 
