### PR TITLE
協賛企業セクションの実装

### DIFF
--- a/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
+++ b/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`(components) organisms/sponsor-section take snap shot 1`] = `
 <div>
   <section
     aria-label="協賛企業"
-    class="twin-1utt4d5-SponsorSectionContainar e1he0e0u0"
+    class="twin-1utt4d5-SponsorSectionContainar e1he0e0u1"
   >
     <h1
       class="twin-f7kb4u-Heading ebaq0s80"
@@ -18,17 +18,12 @@ exports[`(components) organisms/sponsor-section take snap shot 1`] = `
 以下の企業様が鈴鹿高専祭を応援してくれています！
     </p>
     <ul
-      class="twin-4njzar-SponsorSection"
+      class="twin-1xejwjl-SponsorList e1he0e0u0"
     >
       <li
-        class="twin-y76ykx-SponsorSection"
+        class="twin-1g46zvu-Text-SponsorSection epv4mo00"
       >
         株式会社xx
-      </li>
-      <li
-        class="twin-y76ykx-SponsorSection"
-      >
-        ...
       </li>
     </ul>
   </section>

--- a/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
+++ b/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`(components) organisms/sponsor-section take snap shot 1`] = `
+<div>
+  <section
+    aria-label="協賛企業"
+    class="twin-1utt4d5-SponsorSectionContainar e1he0e0u0"
+  >
+    <h1
+      class="twin-f7kb4u-Heading ebaq0s80"
+    >
+      協賛企業
+    </h1>
+    <p
+      class="twin-zuqn7z-Text-SponsorSection epv4mo00"
+    >
+      今年の高専祭は3年ぶりの開催。
+以下の企業様が鈴鹿高専祭を応援してくれています！
+    </p>
+    <p
+      class="twin-zuqn7z-Text-SponsorSection epv4mo00"
+    >
+      ・株式会社xx
+・...
+    </p>
+  </section>
+</div>
+`;

--- a/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
+++ b/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`(components) organisms/sponsor-section take snap shot 1`] = `
 <div>
   <section
     aria-label="協賛企業"
-    class="twin-1utt4d5-SponsorSectionContainar e1he0e0u1"
+    class="twin-1utt4d5-SponsorSectionContainar e1he0e0u0"
   >
     <h1
       class="twin-f7kb4u-Heading ebaq0s80"
@@ -17,9 +17,7 @@ exports[`(components) organisms/sponsor-section take snap shot 1`] = `
       今年の高専祭は3年ぶりの開催。
 以下の企業様が鈴鹿高専祭を応援してくれています！
     </p>
-    <ul
-      class="twin-1xejwjl-SponsorList e1he0e0u0"
-    >
+    <ul>
       <li
         class="twin-1g46zvu-Text-SponsorSection epv4mo00"
       >

--- a/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
+++ b/src/components/organisms/sponsor-section/__snapshots__/sponsor-section.test.tsx.snap
@@ -17,12 +17,20 @@ exports[`(components) organisms/sponsor-section take snap shot 1`] = `
       今年の高専祭は3年ぶりの開催。
 以下の企業様が鈴鹿高専祭を応援してくれています！
     </p>
-    <p
-      class="twin-zuqn7z-Text-SponsorSection epv4mo00"
+    <ul
+      class="twin-4njzar-SponsorSection"
     >
-      ・株式会社xx
-・...
-    </p>
+      <li
+        class="twin-y76ykx-SponsorSection"
+      >
+        株式会社xx
+      </li>
+      <li
+        class="twin-y76ykx-SponsorSection"
+      >
+        ...
+      </li>
+    </ul>
   </section>
 </div>
 `;

--- a/src/components/organisms/sponsor-section/index.tsx
+++ b/src/components/organisms/sponsor-section/index.tsx
@@ -5,19 +5,15 @@ import { Heading } from "../../atoms/heading";
 import { Text } from "../../atoms/text";
 
 const SponsorSectionContainar = tw.section`space-y-[calc(200vw / 63)]`;
-
 const SponsorSection: React.FC<SponsorSectionProperties> = ({ children, sponsors, title, ...rest }) => (
   <SponsorSectionContainar aria-label={"協賛企業"} {...rest}>
     <Heading>{title}</Heading>
     <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
     <ul css={tw`whitespace-pre-wrap`}>
-      {sponsors.map((item, index) => (
-        <li
-          css={tw`list-disc list-inside font-zen text-white text-[calc(12px + 4 * ((100vw - 378px) / 1134))] select-none`}
-          key={index}
-        >
+      {sponsors.map((item, key) => (
+        <Text as={"li"} css={tw`list-disc list-inside`} key={`${item}-${key}`}>
           {item}
-        </li>
+        </Text>
       ))}
     </ul>
   </SponsorSectionContainar>

--- a/src/components/organisms/sponsor-section/index.tsx
+++ b/src/components/organisms/sponsor-section/index.tsx
@@ -5,18 +5,18 @@ import { Heading } from "../../atoms/heading";
 import { Text } from "../../atoms/text";
 
 const SponsorSectionContainar = tw.section`space-y-[calc(200vw / 63)]`;
-const SponsorList = tw.ul``;
+
 const SponsorSection: React.FC<SponsorSectionProperties> = ({ children, sponsors, title, ...rest }) => (
   <SponsorSectionContainar aria-label={"協賛企業"} {...rest}>
     <Heading>{title}</Heading>
     <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
-    <SponsorList>
+    <ul>
       {sponsors.map((item, key) => (
         <Text as={"li"} css={tw`list-disc list-inside`} key={`${item}-${key}`}>
           {item}
         </Text>
       ))}
-    </SponsorList>
+    </ul>
   </SponsorSectionContainar>
 );
 

--- a/src/components/organisms/sponsor-section/index.tsx
+++ b/src/components/organisms/sponsor-section/index.tsx
@@ -10,7 +10,16 @@ const SponsorSection: React.FC<SponsorSectionProperties> = ({ children, sponsors
   <SponsorSectionContainar aria-label={"協賛企業"} {...rest}>
     <Heading>{title}</Heading>
     <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
-    <Text css={tw`whitespace-pre-wrap`}>{sponsors}</Text>
+    <ul css={tw`whitespace-pre-wrap`}>
+      {sponsors.map((item, index) => (
+        <li
+          css={tw`list-disc list-inside font-zen text-white text-[calc(12px + 4 * ((100vw - 378px) / 1134))] select-none`}
+          key={index}
+        >
+          {item}
+        </li>
+      ))}
+    </ul>
   </SponsorSectionContainar>
 );
 

--- a/src/components/organisms/sponsor-section/index.tsx
+++ b/src/components/organisms/sponsor-section/index.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import tw from "twin.macro";
+import { SponsorSectionProperties } from "../../../models";
+import { Heading } from "../../atoms/heading";
+import { Text } from "../../atoms/text";
+
+const SponsorSectionContainar = tw.section`space-y-[calc(200vw / 63)]`;
+
+const SponsorSection: React.FC<SponsorSectionProperties> = ({ children, sponsors, title, ...rest }) => (
+  <SponsorSectionContainar aria-label={"協賛企業"} {...rest}>
+    <Heading>{title}</Heading>
+    <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
+    <Text css={tw`whitespace-pre-wrap`}>{sponsors}</Text>
+  </SponsorSectionContainar>
+);
+
+export { SponsorSection };

--- a/src/components/organisms/sponsor-section/index.tsx
+++ b/src/components/organisms/sponsor-section/index.tsx
@@ -5,17 +5,18 @@ import { Heading } from "../../atoms/heading";
 import { Text } from "../../atoms/text";
 
 const SponsorSectionContainar = tw.section`space-y-[calc(200vw / 63)]`;
+const SponsorList = tw.ul``;
 const SponsorSection: React.FC<SponsorSectionProperties> = ({ children, sponsors, title, ...rest }) => (
   <SponsorSectionContainar aria-label={"協賛企業"} {...rest}>
     <Heading>{title}</Heading>
     <Text css={tw`whitespace-pre-wrap`}>{children}</Text>
-    <ul css={tw`whitespace-pre-wrap`}>
+    <SponsorList>
       {sponsors.map((item, key) => (
         <Text as={"li"} css={tw`list-disc list-inside`} key={`${item}-${key}`}>
           {item}
         </Text>
       ))}
-    </ul>
+    </SponsorList>
   </SponsorSectionContainar>
 );
 

--- a/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
@@ -6,7 +6,7 @@ type Story = ComponentStoryObj<T>;
 
 const data = {
   children: "今年の高専祭は3年ぶりの開催。\n以下の企業様が鈴鹿高専祭を応援してくれています！",
-  sponsors: "・株式会社xx\n・...",
+  sponsors: ["株式会社xx", "..."],
   title: "協賛企業",
 };
 

--- a/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
@@ -6,7 +6,7 @@ type Story = ComponentStoryObj<T>;
 
 const data = {
   children: "今年の高専祭は3年ぶりの開催。\n以下の企業様が鈴鹿高専祭を応援してくれています！",
-  sponsors: ["株式会社xx", "..."],
+  sponsors: ["株式会社xx"],
   title: "協賛企業",
 };
 

--- a/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.stories.tsx
@@ -1,0 +1,18 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { SponsorSection } from ".";
+
+type T = typeof SponsorSection;
+type Story = ComponentStoryObj<T>;
+
+const data = {
+  children: "今年の高専祭は3年ぶりの開催。\n以下の企業様が鈴鹿高専祭を応援してくれています！",
+  sponsors: "・株式会社xx\n・...",
+  title: "協賛企業",
+};
+
+export default {
+  args: { children: data.children, sponsors: data.sponsors, title: data.title },
+  component: SponsorSection,
+} as ComponentMeta<T>;
+
+export const Default: Story = {};

--- a/src/components/organisms/sponsor-section/sponsor-section.test.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.test.tsx
@@ -1,14 +1,17 @@
 import { composeStories } from "@storybook/testing-react";
 import "@testing-library/jest-dom";
-import { render } from "@testing-library/react";
+import { getByRole, render } from "@testing-library/react";
 import * as stories from "./sponsor-section.stories";
 
 const { Default } = composeStories(stories);
 
-const options = {
+const sponsoroptions = {
   name: "協賛企業",
 };
 
+const listoptions = {
+  name: "",
+};
 describe("(components) organisms/sponsor-section", () => {
   test("to be organisms", () => {
     const { container } = render(<Default />);
@@ -16,10 +19,15 @@ describe("(components) organisms/sponsor-section", () => {
   });
   test("to be [role=region]", () => {
     const { getByRole } = render(<Default />);
-    expect(getByRole("region", options));
+    expect(getByRole("region", sponsoroptions));
+  });
+  test("to be [role=list]", () => {
+    const { getByRole } = render(<Default />);
+    expect(getByRole("list", listoptions));
   });
   test("take snap shot", () => {
     const { container } = render(<Default />);
+    expect(getByRole);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/sponsor-section/sponsor-section.test.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.test.tsx
@@ -1,6 +1,6 @@
 import { composeStories } from "@storybook/testing-react";
 import "@testing-library/jest-dom";
-import { getByRole, render } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import * as stories from "./sponsor-section.stories";
 
 const { Default } = composeStories(stories);
@@ -27,7 +27,6 @@ describe("(components) organisms/sponsor-section", () => {
   });
   test("take snap shot", () => {
     const { container } = render(<Default />);
-    expect(getByRole);
     expect(container).toMatchSnapshot();
   });
 });

--- a/src/components/organisms/sponsor-section/sponsor-section.test.tsx
+++ b/src/components/organisms/sponsor-section/sponsor-section.test.tsx
@@ -1,0 +1,25 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./sponsor-section.stories";
+
+const { Default } = composeStories(stories);
+
+const options = {
+  name: "協賛企業",
+};
+
+describe("(components) organisms/sponsor-section", () => {
+  test("to be organisms", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeOrganism();
+  });
+  test("to be [role=region]", () => {
+    const { getByRole } = render(<Default />);
+    expect(getByRole("region", options));
+  });
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -90,5 +90,5 @@ export type ContactSectionProperties = Omit<React.ComponentProps<React.ReactHTML
 export type SponsorSectionProperties = Omit<React.ComponentProps<React.ReactHTML["section"]>, "children"> & {
   title: string;
   children: string;
-  sponsors: string;
+  sponsors: Sponsors;
 };

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -86,3 +86,9 @@ export type ContactSectionProperties = Omit<React.ComponentProps<React.ReactHTML
   link: string;
   children: string;
 };
+
+export type SponsorSectionProperties = Omit<React.ComponentProps<React.ReactHTML["section"]>, "children"> & {
+  title: string;
+  children: string;
+  sponsors: string;
+};


### PR DESCRIPTION
# 📝 what

- 協賛企業セクションの実装

# 😎 why

- RCください（懇願）
- propに配列定義したかったけど力及ばず

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

close #137 
