### PR TITLE
β版のUIの作成

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - dev
     paths:
-      - '**.stories.tsx'
+      - 'components/**/index.tsx'
 
 jobs:
   chromatic-deployment:

--- a/src/components/molecules/twitter/__snapshots__/twitter.test.tsx.snap
+++ b/src/components/molecules/twitter/__snapshots__/twitter.test.tsx.snap
@@ -2,15 +2,33 @@
 
 exports[`(components) molecules/twitter take snap shot 1`] = `
 <div>
-  <figure>
-    <a
-      class="twitter-timeline"
-      data-height="410"
-      data-width="288"
-      href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+  <figure
+    class="twin-v60la1-TwitterContainer euts3j72"
+  >
+    <div
+      class="twin-xhqua6-TwitterMB euts3j71"
     >
-      Tweets by KOSENFESTA
-    </a>
+      <a
+        class="twitter-timeline"
+        data-height="420"
+        data-width="240"
+        href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+      >
+        Tweets by KOSENFESTA
+      </a>
+    </div>
+    <div
+      class="twin-1jh3ske-TwitterPC euts3j70"
+    >
+      <a
+        class="twitter-timeline"
+        data-height="410"
+        data-width="288"
+        href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+      >
+        Tweets by KOSENFESTA
+      </a>
+    </div>
   </figure>
 </div>
 `;

--- a/src/components/molecules/twitter/__snapshots__/twitter.test.tsx.snap
+++ b/src/components/molecules/twitter/__snapshots__/twitter.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`(components) molecules/twitter take snap shot 1`] = `
       class="twin-xhqua6-TwitterMB euts3j71"
     >
       <a
-        class="twitter-timeline"
+        class="twitter-timeline twin-1yx28h9-AnchorText ey6ijqd0"
         data-height="420"
         data-width="240"
         href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
@@ -21,7 +21,7 @@ exports[`(components) molecules/twitter take snap shot 1`] = `
       class="twin-1jh3ske-TwitterPC euts3j70"
     >
       <a
-        class="twitter-timeline"
+        class="twitter-timeline twin-1yx28h9-AnchorText ey6ijqd0"
         data-height="410"
         data-width="288"
         href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"

--- a/src/components/molecules/twitter/index.tsx
+++ b/src/components/molecules/twitter/index.tsx
@@ -1,4 +1,11 @@
 import React, { useEffect } from "react";
+import tw from "twin.macro";
+
+const TwitterContainer = tw.figure`w-[300px] h-[420px]`;
+
+const TwitterMB = tw.div`inline sm:hidden`;
+
+const TwitterPC = tw.div`hidden sm:inline`;
 
 const Twitter: React.FC = () => {
   useEffect(() => {
@@ -10,16 +17,28 @@ const Twitter: React.FC = () => {
     };
   }, []);
   return (
-    <figure>
-      <a
-        className={"twitter-timeline"}
-        data-width={"288"}
-        data-height={"410"}
-        href={"https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"}
-      >
-        Tweets by KOSENFESTA
-      </a>
-    </figure>
+    <TwitterContainer>
+      <TwitterMB>
+        <a
+          className={"twitter-timeline"}
+          data-width={"240"}
+          data-height={"420"}
+          href={"https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"}
+        >
+          Tweets by KOSENFESTA
+        </a>
+      </TwitterMB>
+      <TwitterPC>
+        <a
+          className={"twitter-timeline"}
+          data-width={"288"}
+          data-height={"410"}
+          href={"https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"}
+        >
+          Tweets by KOSENFESTA
+        </a>
+      </TwitterPC>
+    </TwitterContainer>
   );
 };
 

--- a/src/components/molecules/twitter/index.tsx
+++ b/src/components/molecules/twitter/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import tw from "twin.macro";
+import {AnchorText} from "../../atoms/anchor-text";
 
 const TwitterContainer = tw.figure`w-[300px] h-[420px]`;
 
@@ -19,24 +20,24 @@ const Twitter: React.FC = () => {
   return (
     <TwitterContainer>
       <TwitterMB>
-        <a
+        <AnchorText
           className={"twitter-timeline"}
           data-width={"240"}
           data-height={"420"}
           href={"https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"}
         >
           Tweets by KOSENFESTA
-        </a>
+        </AnchorText>
       </TwitterMB>
       <TwitterPC>
-        <a
+        <AnchorText
           className={"twitter-timeline"}
           data-width={"288"}
           data-height={"410"}
           href={"https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"}
         >
           Tweets by KOSENFESTA
-        </a>
+        </AnchorText>
       </TwitterPC>
     </TwitterContainer>
   );

--- a/src/components/molecules/twitter/index.tsx
+++ b/src/components/molecules/twitter/index.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import tw from "twin.macro";
-import {AnchorText} from "../../atoms/anchor-text";
+import { AnchorText } from "../../atoms/anchor-text";
 
 const TwitterContainer = tw.figure`w-[300px] h-[420px]`;
 

--- a/src/components/organisms/footer/__snapshots__/footer.test.tsx.snap
+++ b/src/components/organisms/footer/__snapshots__/footer.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`(components) organisms/footer take snap shot 1`] = `
 <div>
   <footer
-    class="twin-ey91xp-FooterBox e1cwxp960"
+    class="twin-1h92n56-FooterBox e1cwxp960"
     role="contentinfo"
   >
     <a

--- a/src/components/organisms/footer/index.tsx
+++ b/src/components/organisms/footer/index.tsx
@@ -3,7 +3,7 @@ import tw from "twin.macro";
 import type { FooterProperties } from "../../../models";
 import { AnchorText } from "../../atoms/anchor-text";
 
-const FooterBox = tw.footer`bg-black text-center leading-[calc(12px + 4 * ((100vw - 378px) / 1134))] py-[calc(100vw / 63)] w-screen`;
+const FooterBox = tw.footer`bg-black text-center leading-[calc(12px + 4 * ((100vw - 378px) / 1134))] py-[calc(100vw / 63)]`;
 
 const Footer: React.FC<FooterProperties> = ({ link, children, ...rest }) => (
   <FooterBox role={"contentinfo"} {...rest}>

--- a/src/components/organisms/sns-section/__snapshots__/sns-section.test.tsx.snap
+++ b/src/components/organisms/sns-section/__snapshots__/sns-section.test.tsx.snap
@@ -11,15 +11,33 @@ exports[`(components) organisms/sns-section take snap shot 1`] = `
     >
       SNS
     </h1>
-    <figure>
-      <a
-        class="twitter-timeline"
-        data-height="410"
-        data-width="288"
-        href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+    <figure
+      class="twin-v60la1-TwitterContainer euts3j72"
+    >
+      <div
+        class="twin-xhqua6-TwitterMB euts3j71"
       >
-        Tweets by KOSENFESTA
-      </a>
+        <a
+          class="twitter-timeline"
+          data-height="420"
+          data-width="240"
+          href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+        >
+          Tweets by KOSENFESTA
+        </a>
+      </div>
+      <div
+        class="twin-1jh3ske-TwitterPC euts3j70"
+      >
+        <a
+          class="twitter-timeline"
+          data-height="410"
+          data-width="288"
+          href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
+        >
+          Tweets by KOSENFESTA
+        </a>
+      </div>
     </figure>
   </section>
 </div>

--- a/src/components/organisms/sns-section/__snapshots__/sns-section.test.tsx.snap
+++ b/src/components/organisms/sns-section/__snapshots__/sns-section.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`(components) organisms/sns-section take snap shot 1`] = `
         class="twin-xhqua6-TwitterMB euts3j71"
       >
         <a
-          class="twitter-timeline"
+          class="twitter-timeline twin-1yx28h9-AnchorText ey6ijqd0"
           data-height="420"
           data-width="240"
           href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"
@@ -30,7 +30,7 @@ exports[`(components) organisms/sns-section take snap shot 1`] = `
         class="twin-1jh3ske-TwitterPC euts3j70"
       >
         <a
-          class="twitter-timeline"
+          class="twitter-timeline twin-1yx28h9-AnchorText ey6ijqd0"
           data-height="410"
           data-width="288"
           href="https://twitter.com/KOSENFESTA?ref_src=twsrc%5Etfw"

--- a/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
+++ b/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`(components) templates/layout take snap shot 1`] = `
         <section />
       </main>
       <footer
-        class="twin-ey91xp-FooterBox e1cwxp960"
+        class="twin-1h92n56-FooterBox e1cwxp960"
         role="contentinfo"
       >
         <a

--- a/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
+++ b/src/components/templates/layout/__snapshots__/layout.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`(components) templates/layout take snap shot 1`] = `
     class="twin-1m2qlh2-LayoutBox e1o6lh2y2"
   >
     <div
-      class="twin-4lz3vw-MainBox e1o6lh2y1"
+      class="twin-1xz4r0p-MainBox e1o6lh2y1"
     >
       <header
         class="twin-1khm9dj-HeroSectionContainer e1bk5cli1"
@@ -33,12 +33,11 @@ exports[`(components) templates/layout take snap shot 1`] = `
           </p>
         </div>
       </header>
-      <div
-        class="twin-115a0sk-Main e1o6lh2y0"
-        role="main"
+      <main
+        class="twin-197sar1-Main e1o6lh2y0"
       >
         <section />
-      </div>
+      </main>
       <footer
         class="twin-ey91xp-FooterBox e1cwxp960"
         role="contentinfo"

--- a/src/components/templates/layout/index.tsx
+++ b/src/components/templates/layout/index.tsx
@@ -6,15 +6,15 @@ import { HeroSection } from "../../organisms/hero-section";
 
 const LayoutBox = tw.div`min-h-screen bg-background-gray`;
 
-const MainBox = tw.div`flex flex-col`;
+const MainBox = tw.div`flex flex-col space-y-[calc(4300vw / 378)]`;
 
-const Main = tw.div`mx-[calc(800vw / 63)]`;
+const Main = tw.main`mx-[calc(800vw / 63)] space-y-[calc(4300vw / 378)]`;
 
 const Layout: React.FC<LayoutProperties> = ({ children, ...rest }) => (
   <LayoutBox {...rest}>
     <MainBox>
       <HeroSection date={"2022.10.30-31"} title={"第57回鈴鹿高専祭"} />
-      <Main role={"main"}>{children}</Main>
+      <Main>{children}</Main>
       <Footer link={"https://github.com/suzuka-kosen-festa/2022-HP/blob/main/LICENSE"}>
         &copy; 第57回鈴鹿高専祭実行委員会
       </Footer>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,7 +41,7 @@ const Home: NextPage<Properties> = ({ result }) => (
       </SponsorSection>
     )}
     <SnsSection title={"SNS"} />
-    <ContactSection buttonText={"お問い合わせ"} title={"お問い合わせ"} link={"https://example.com"}>
+    <ContactSection buttonText={"お問い合わせ"} title={"お問い合わせ"} link={"https://docs.google.com/forms/d/e/1FAIpQLSeMMA1YJbqClu_6ktzhV8u9hjwfOtJAMT3OLiIpyJJsqzGbdw/viewform"}>
       第57回鈴鹿高専祭に関するお問い合わせは下のボタンからお願いいたします。(google formsが開きます)
     </ContactSection>
     <MapSection

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -41,7 +41,11 @@ const Home: NextPage<Properties> = ({ result }) => (
       </SponsorSection>
     )}
     <SnsSection title={"SNS"} />
-    <ContactSection buttonText={"お問い合わせ"} title={"お問い合わせ"} link={"https://docs.google.com/forms/d/e/1FAIpQLSeMMA1YJbqClu_6ktzhV8u9hjwfOtJAMT3OLiIpyJJsqzGbdw/viewform"}>
+    <ContactSection
+      buttonText={"お問い合わせ"}
+      title={"お問い合わせ"}
+      link={"https://docs.google.com/forms/d/e/1FAIpQLSeMMA1YJbqClu_6ktzhV8u9hjwfOtJAMT3OLiIpyJJsqzGbdw/viewform"}
+    >
       第57回鈴鹿高専祭に関するお問い合わせは下のボタンからお願いいたします。(google formsが開きます)
     </ContactSection>
     <MapSection

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,17 +1,63 @@
-import type { NextPage } from "next";
+import type { GetStaticProps, InferGetStaticPropsType, NextPage } from "next";
 import React from "react";
-import { Text } from "../components/atoms/text";
+import { AboutSection } from "../components/organisms/about-section";
+import { ContactSection } from "../components/organisms/contact-section";
+import { FestaSection } from "../components/organisms/festa-section";
+import { MapSection } from "../components/organisms/map-section";
+import { SnsSection } from "../components/organisms/sns-section";
+import { SponsorSection } from "../components/organisms/sponsor-section";
+import { _Field, RYaml, Sponsors } from "../models";
+import { getDataByField } from "../utils/api";
 import { Seo } from "../utils/seo";
 
-const Home: NextPage = () => (
+type Properties = InferGetStaticPropsType<typeof getStaticProps>;
+
+// eslint-disable-next-line unicorn/prevent-abbreviations
+export const getStaticProps: GetStaticProps<{ result: RYaml<Sponsors> }> = () => {
+  const fields: Array<_Field> = [{ __typename: "Sponsors", path: "sponsors" }];
+  const data = getDataByField(fields);
+  const result = data.find(({ field }) => field === "sponsors") as RYaml<Sponsors>;
+  return {
+    props: {
+      result,
+    },
+  };
+};
+
+const Home: NextPage<Properties> = ({ result }) => (
   <React.Fragment>
     <Seo
       title={"Re:ROAD | 第57回鈴鹿高専祭"}
       description={"まだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。"}
     />
-    <main>
-      <Text>Hello Next.js</Text>
-    </main>
+    <FestaSection title={"今年のテーマ「Re:ROAD」について"}>
+      {
+        "第57回鈴鹿高専祭、テーマは「Re:ROAD」\n今回のテーマ「Re:ROAD」には「道（Road）」を創り直す（Re）という意味と、「弾をこめる・再補填する（Reload）」という意味を使い、「今年の準備をする」「来年以降、これから先のための高専祭を行う」という想いが込められています。\n\n2019年を最後に鈴鹿高専祭は行われていません。\nそのため過去のデータもあまり残っておらず本当に1から、いや0からのスタートです。\nまだ何色にも色づいていない第57回鈴鹿高専祭を今から色づけていきます。"
+      }
+    </FestaSection>
+    {result.data !== null && (
+      <SponsorSection title={"協賛企業"} sponsors={result.data}>
+        今年の高専祭は3年ぶりの開催。 以下の企業様が鈴鹿高専祭を応援してくれています！
+      </SponsorSection>
+    )}
+    <SnsSection title={"SNS"} />
+    <ContactSection buttonText={"お問い合わせ"} title={"お問い合わせ"} link={"https://example.com"}>
+      第57回鈴鹿高専祭に関するお問い合わせは下のボタンからお願いいたします。(google formsが開きます)
+    </ContactSection>
+    <MapSection
+      center={{
+        lat: 34.851_671_242_413_17,
+        lng: 136.581_323_097_843_55,
+      }}
+      zoom={15}
+      title={"アクセス"}
+      label={"鈴鹿工業高等専門学校"}
+    >
+      {"510-0294 三重県鈴鹿市白子町\n近鉄白子駅から徒歩約30分\n近くのバス停から約7分"}
+    </MapSection>
+    <AboutSection buttonText={"鈴鹿高専ホームページ"} link={"https://www.suzuka-ct.ac.jp/"} title={"鈴鹿高専について"}>
+      詳しくは本校ホームページをご覧ください。
+    </AboutSection>
   </React.Fragment>
 );
 


### PR DESCRIPTION
# 📝 what

- β版のUIの作成
- Twitterの部分的なレスポンシブ対応

# 😎 why

- width: 300px以下のスマホには対応できていない。
- 対応する場合はTwitterに就職してレスポンスのiframeに当てられるStyleを変更してください

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

close #151 
