### PR TITLE
feat: design tokens transformerの追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "jest",
     "test:watch": "jest watch",
     "test:update": "jest -u",
-    "gen:style": "node ./scripts/build.js",
+    "gen:style": "token-transformer data/tokens.json data/tmp.json && node ./scripts/build.js && rimraf data/tmp.json",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
@@ -84,8 +84,10 @@
     "jest-environment-jsdom": "29.0.3",
     "postcss": "8.4.16",
     "prettier": "2.7.1",
+    "rimraf": "^3.0.2",
     "style-dictionary": "3.7.1",
     "tailwindcss": "3.1.8",
+    "token-transformer": "^0.0.27",
     "twin.macro": "2.8.2",
     "typescript": "4.8.3",
     "webpack": "5.74.0"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ const scssTransforms = baseTransforms.concat(["name/cti/kebab"]);
 
 function getStyleDictionaryConfig() {
   return {
-    source: [`data/tokens.json`],
+    source: ["data/tmp.json"],
     format: {
       createArray,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18831,6 +18831,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"token-transformer@npm:^0.0.27":
+  version: 0.0.27
+  resolution: "token-transformer@npm:0.0.27"
+  dependencies:
+    yargs: ^17.4.1
+  bin:
+    token-transformer: index.js
+  checksum: 8bc157a42faba5ced132520440d91b7966e1ec60919d18a4a03e4064a9bb8727970fbfa51292f71097870f558d8b3780c2aad145df3da83d495ee4fe3e9cb4ae
+  languageName: node
+  linkType: hard
+
 "toml-eslint-parser@npm:^0.4.0":
   version: 0.4.0
   resolution: "toml-eslint-parser@npm:0.4.0"
@@ -20066,8 +20077,10 @@ __metadata:
     prettier: 2.7.1
     react: 18.2.0
     react-dom: 18.2.0
+    rimraf: ^3.0.2
     style-dictionary: 3.7.1
     tailwindcss: 3.1.8
+    token-transformer: ^0.0.27
     ts-pattern: 4.0.5
     twin.macro: 2.8.2
     typescript: 4.8.3
@@ -20621,7 +20634,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs@npm:^17.3.1":
+"yargs@npm:^17.3.1, yargs@npm:^17.4.1":
   version: 17.5.1
   resolution: "yargs@npm:17.5.1"
   dependencies:


### PR DESCRIPTION
# ℹ️ issue

close #169  

# 📝 what

- design token transformerを設定

# 😎 why

- figma tokensの生成するトークンに対応するため

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

