### PR TITLE
fix!: Fix workflow's checkout ref to workflow_run's head sha

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# 📝 what

- CIの`checkout ref`を`workflow_run`のhead shaに変更した

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [ ] 動作検証をした

# ℹ️ issue

ref #237 
