### PR TITLE
feat: Create sub heading component

### DIFF
--- a/src/components/atoms/sub-heading/__snapshots__/sub-heading.test.tsx.snap
+++ b/src/components/atoms/sub-heading/__snapshots__/sub-heading.test.tsx.snap
@@ -1,0 +1,11 @@
+// Vitest Snapshot v1
+
+exports[`(components) atoms/text > take snap shot 1`] = `
+<div>
+  <h2
+    class="css-1a2c2qr"
+  >
+    This is test
+  </h2>
+</div>
+`;

--- a/src/components/atoms/sub-heading/index.tsx
+++ b/src/components/atoms/sub-heading/index.tsx
@@ -1,5 +1,5 @@
-import tw from "twin.macro"
+import tw from "twin.macro";
 
-const SubHeading = tw.h2`font-zen text-text font-bold text-base sm:text-2xl select-none`
+const SubHeading = tw.h2`font-zen text-text font-bold text-base sm:text-2xl select-none`;
 
-export { SubHeading }
+export { SubHeading };

--- a/src/components/atoms/sub-heading/index.tsx
+++ b/src/components/atoms/sub-heading/index.tsx
@@ -1,0 +1,5 @@
+import tw from "twin.macro"
+
+const SubHeading = tw.h2`font-zen text-text font-bold text-base sm:text-2xl select-none`
+
+export { SubHeading }

--- a/src/components/atoms/sub-heading/sub-heading.stories.tsx
+++ b/src/components/atoms/sub-heading/sub-heading.stories.tsx
@@ -1,0 +1,19 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { SubHeading } from ".";
+
+type T = typeof SubHeading;
+type Story = ComponentStoryObj<T>;
+
+const data = {
+  sentence: "This is test",
+};
+
+export default {
+  args: {children: data.sentence},
+  argTypes: {
+    children: {description: "Context of sub heading", control: {type: "text"}},
+  },
+  component: SubHeading,
+} as ComponentMeta<T>
+
+export const Default: Story = {}

--- a/src/components/atoms/sub-heading/sub-heading.stories.tsx
+++ b/src/components/atoms/sub-heading/sub-heading.stories.tsx
@@ -9,11 +9,11 @@ const data = {
 };
 
 export default {
-  args: {children: data.sentence},
+  args: { children: data.sentence },
   argTypes: {
-    children: {description: "Context of sub heading", control: {type: "text"}},
+    children: { description: "Context of sub heading", control: { type: "text" } },
   },
   component: SubHeading,
-} as ComponentMeta<T>
+} as ComponentMeta<T>;
 
-export const Default: Story = {}
+export const Default: Story = {};

--- a/src/components/atoms/sub-heading/sub-heading.test.tsx
+++ b/src/components/atoms/sub-heading/sub-heading.test.tsx
@@ -1,0 +1,25 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./sub-heading.stories";
+
+const { Default } = composeStories(stories);
+
+const options = {
+  name: "This is test",
+};
+
+describe("(components) atoms/text", () => {
+  test("to be atoms", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeAtom();
+  });
+  test("to be [role=heading]", () => {
+    const { getByRole } = render(<Default />);
+    expect(getByRole("heading", options));
+  });
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
# 📝 what

- component内で使用するheading componentを実装

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

ref #192 
