### PR TITLE
feat: Create bazaar card component

### DIFF
--- a/src/components/molecules/bazaar-card/__snapshots__/bazaar-card.test.tsx.snap
+++ b/src/components/molecules/bazaar-card/__snapshots__/bazaar-card.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`(components) molecules/bazaar-card > take snap shot 1`] = `
   >
     <img
       alt="バザーに関するイメージ画像"
-      class="css-l4njp5-BazaarCard"
+      class="css-61q9gc-BazaarCard"
       height="200"
       src="https://panproduct.com/blog/wp-content/uploads/2021/07/32.png"
       width="300"
@@ -30,7 +30,7 @@ exports[`(components) molecules/bazaar-card > take snap shot 1`] = `
         A.作品展示
       </h2>
       <p
-        class="css-1s6ovra-BazaarCard"
+        class="css-vaqku0-BazaarCard"
       >
         美術部員が描き溜めてきた作品たちを展示します。ぜひ見に来てね！
       </p>

--- a/src/components/molecules/bazaar-card/__snapshots__/bazaar-card.test.tsx.snap
+++ b/src/components/molecules/bazaar-card/__snapshots__/bazaar-card.test.tsx.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1
+
+exports[`(components) molecules/bazaar-card > take snap shot 1`] = `
+<div>
+  <li
+    class="css-16wvccd"
+  >
+    <img
+      alt="バザーに関するイメージ画像"
+      class="css-l4njp5-BazaarCard"
+      height="200"
+      src="https://panproduct.com/blog/wp-content/uploads/2021/07/32.png"
+      width="300"
+    />
+    <div
+      class="css-z0erpm"
+    >
+      <div
+        class="css-1q8fkzn"
+      >
+        <p
+          class="css-jprqak"
+        >
+          美術部
+        </p>
+      </div>
+      <h2
+        class="css-hh2gwj"
+      >
+        A.作品展示
+      </h2>
+      <p
+        class="css-1s6ovra-BazaarCard"
+      >
+        美術部員が描き溜めてきた作品たちを展示します。ぜひ見に来てね！
+      </p>
+      <ul
+        class="css-luxo22"
+      >
+        <li>
+          <p
+            class="css-4gn9jk"
+          >
+            無料
+          </p>
+        </li>
+      </ul>
+    </div>
+  </li>
+</div>
+`;

--- a/src/components/molecules/bazaar-card/bazaar-card.stories.tsx
+++ b/src/components/molecules/bazaar-card/bazaar-card.stories.tsx
@@ -1,0 +1,23 @@
+import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
+import { ComponentPropsWithoutRef } from 'react';
+import { BazaarCard } from ".";
+
+type T = typeof BazaarCard;
+type Story = ComponentStoryObj<T>;
+type Meta = ComponentMeta<T>;
+
+const args: ComponentPropsWithoutRef<T> = {
+  name: "A.作品展示",
+  description: "美術部員が描き溜めてきた作品たちを展示します。ぜひ見に来てね！",
+  image: "https://panproduct.com/blog/wp-content/uploads/2021/07/32.png",
+  prices: ["無料"],
+  group: "美術部"
+};
+
+export default {
+  args,
+  argTypes: {},
+  component: BazaarCard,
+} as Meta;
+
+export const Default: Story = {};

--- a/src/components/molecules/bazaar-card/bazaar-card.stories.tsx
+++ b/src/components/molecules/bazaar-card/bazaar-card.stories.tsx
@@ -1,5 +1,5 @@
 import type { ComponentStoryObj, ComponentMeta } from "@storybook/react";
-import { ComponentPropsWithoutRef } from 'react';
+import { ComponentPropsWithoutRef } from "react";
 import { BazaarCard } from ".";
 
 type T = typeof BazaarCard;
@@ -11,7 +11,7 @@ const args: ComponentPropsWithoutRef<T> = {
   description: "美術部員が描き溜めてきた作品たちを展示します。ぜひ見に来てね！",
   image: "https://panproduct.com/blog/wp-content/uploads/2021/07/32.png",
   prices: ["無料"],
-  group: "美術部"
+  group: "美術部",
 };
 
 export default {

--- a/src/components/molecules/bazaar-card/bazaar-card.test.tsx
+++ b/src/components/molecules/bazaar-card/bazaar-card.test.tsx
@@ -1,0 +1,17 @@
+import { composeStories } from "@storybook/testing-react";
+import "@testing-library/jest-dom";
+import { render } from "@testing-library/react";
+import * as stories from "./bazaar-card.stories";
+
+const { Default } = composeStories(stories);
+
+describe("(components) molecules/bazaar-card", () => {
+  test("to be molecules", () => {
+    const { container } = render(<Default />);
+    expect(container).toBeMolecule();
+  });
+  test("take snap shot", () => {
+    const { container } = render(<Default />);
+    expect(container).toMatchSnapshot();
+  });
+});

--- a/src/components/molecules/bazaar-card/index.tsx
+++ b/src/components/molecules/bazaar-card/index.tsx
@@ -1,0 +1,47 @@
+import type { FC } from "react";
+import tw, {css} from "twin.macro";
+import type { BazaarCardProperties, ChipProperties } from "./types/model";
+
+const ChipBox = tw.div`inline-flex items-start bg-primary-purple px-4 py-1 rounded-2xl`
+
+const ChipText = tw.p`font-zen text-white font-bold text-xs sm:text-base select-none`
+
+const BazaarCardBox = tw.li`inline-flex flex-col xs:w-75 border border-border-primary rounded-2xl overflow-hidden`
+
+const BazaarCardImage = tw.img`h-full`
+
+const BazaarCardContent = tw.div`inline-flex flex-col items-start px-2 py-2 space-y-2 sm:(py-4 space-y-4)`
+
+const BazaarCardHeading = tw.h2`font-zen font-bold text-text text-base sm:text-2xl select-none`
+
+const BazaarCardDescription = tw.p`font-zen font-bold text-gray-700 text-xs sm:text-base select-none`
+
+const BazaarCardPrices = tw.ul`flex space-x-2 sm:space-x-3`
+
+const BazaarCardPrice = tw.p`font-zen font-bold text-text text-xs sm:text-base select-none`
+
+const Chip: FC<ChipProperties> = ({group}) => (
+  <ChipBox>
+    <ChipText>{group}</ChipText>
+  </ChipBox>
+)
+
+const BazaarCard: FC<BazaarCardProperties> = ({ name, description, image, prices, group }) => (
+  <BazaarCardBox>
+    <BazaarCardImage css={css`aspect-ratio: 3 / 2;`} src={image} alt="バザーに関するイメージ画像" width={300} height={200} />
+    <BazaarCardContent>
+      <Chip group={group} />
+      <BazaarCardHeading>{name}</BazaarCardHeading>
+      <BazaarCardDescription css={css`width: fit-content;`}>{description}</BazaarCardDescription>
+      <BazaarCardPrices>
+        {prices.map((price) => (
+          <li key={price}>
+            <BazaarCardPrice>{price}</BazaarCardPrice>
+          </li>
+        ))}
+      </BazaarCardPrices>
+    </BazaarCardContent>
+  </BazaarCardBox>
+);
+
+export { BazaarCard };

--- a/src/components/molecules/bazaar-card/index.tsx
+++ b/src/components/molecules/bazaar-card/index.tsx
@@ -1,40 +1,54 @@
 import type { FC } from "react";
-import tw, {css} from "twin.macro";
+import tw, { css } from "twin.macro";
 import type { BazaarCardProperties, ChipProperties } from "./types/model";
 
-const ChipBox = tw.div`inline-flex items-start bg-primary-purple px-4 py-1 rounded-2xl`
+const ChipBox = tw.div`inline-flex items-start bg-primary-purple px-4 py-1 rounded-2xl`;
 
-const ChipText = tw.p`font-zen text-white font-bold text-xs sm:text-base select-none`
+const ChipText = tw.p`font-zen text-white font-bold text-xs sm:text-base select-none`;
 
-const BazaarCardBox = tw.li`inline-flex flex-col xs:w-75 border border-border-primary rounded-2xl overflow-hidden`
+const BazaarCardBox = tw.li`inline-flex flex-col xs:w-75 border border-border-primary rounded-2xl overflow-hidden`;
 
-const BazaarCardImage = tw.img`h-full`
+const BazaarCardImage = tw.img`h-full`;
 
-const BazaarCardContent = tw.div`inline-flex flex-col items-start px-2 py-2 space-y-2 sm:(py-4 space-y-4)`
+const BazaarCardContent = tw.div`inline-flex flex-col items-start px-2 py-2 space-y-2 sm:(py-4 space-y-4)`;
 
-const BazaarCardHeading = tw.h2`font-zen font-bold text-text text-base sm:text-2xl select-none`
+const BazaarCardHeading = tw.h2`font-zen font-bold text-text text-base sm:text-2xl select-none`;
 
-const BazaarCardDescription = tw.p`font-zen font-bold text-gray-700 text-xs sm:text-base select-none`
+const BazaarCardDescription = tw.p`font-zen font-bold text-gray-700 text-xs sm:text-base select-none`;
 
-const BazaarCardPrices = tw.ul`flex space-x-2 sm:space-x-3`
+const BazaarCardPrices = tw.ul`flex space-x-2 sm:space-x-3`;
 
-const BazaarCardPrice = tw.p`font-zen font-bold text-text text-xs sm:text-base select-none`
+const BazaarCardPrice = tw.p`font-zen font-bold text-text text-xs sm:text-base select-none`;
 
-const Chip: FC<ChipProperties> = ({group}) => (
+const Chip: FC<ChipProperties> = ({ group }) => (
   <ChipBox>
     <ChipText>{group}</ChipText>
   </ChipBox>
-)
+);
 
 const BazaarCard: FC<BazaarCardProperties> = ({ name, description, image, prices, group }) => (
   <BazaarCardBox>
-    <BazaarCardImage css={css`aspect-ratio: 3 / 2;`} src={image} alt="バザーに関するイメージ画像" width={300} height={200} />
+    <BazaarCardImage
+      css={css`
+        aspect-ratio: 3 / 2;
+      `}
+      src={image}
+      alt="バザーに関するイメージ画像"
+      width={300}
+      height={200}
+    />
     <BazaarCardContent>
       <Chip group={group} />
       <BazaarCardHeading>{name}</BazaarCardHeading>
-      <BazaarCardDescription css={css`width: fit-content;`}>{description}</BazaarCardDescription>
+      <BazaarCardDescription
+        css={css`
+          width: fit-content;
+        `}
+      >
+        {description}
+      </BazaarCardDescription>
       <BazaarCardPrices>
-        {prices.map((price) => (
+        {prices.map(price => (
           <li key={price}>
             <BazaarCardPrice>{price}</BazaarCardPrice>
           </li>

--- a/src/components/molecules/bazaar-card/types/model.ts
+++ b/src/components/molecules/bazaar-card/types/model.ts
@@ -1,0 +1,11 @@
+export type ChipProperties = {
+  group: string
+}
+
+export type BazaarCardProperties = {
+  name: string;
+  description: string;
+  image: string;
+  prices: ReadonlyArray<string>;
+  group: string;
+};

--- a/src/components/molecules/bazaar-card/types/model.ts
+++ b/src/components/molecules/bazaar-card/types/model.ts
@@ -1,6 +1,6 @@
 export type ChipProperties = {
-  group: string
-}
+  group: string;
+};
 
 export type BazaarCardProperties = {
   name: string;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -61,9 +61,15 @@ module.exports = {
         "main-md": "8vw",
         main: "13.4vw",
       },
+      screens: {
+        xs: "360px"
+      },
       space: {
         2.25: "0.5625rem",
       },
+      width: {
+        75: "18.75rem"
+      }
     },
   },
   variants: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -62,14 +62,14 @@ module.exports = {
         main: "13.4vw",
       },
       screens: {
-        xs: "360px"
+        xs: "360px",
       },
       space: {
         2.25: "0.5625rem",
       },
       width: {
-        75: "18.75rem"
-      }
+        75: "18.75rem",
+      },
     },
   },
   variants: {


### PR DESCRIPTION
# 📝 what

- バザー用のカードを実装

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

ref #217 
