### PR TITLE
fix: Create custom hooks and fix scroll issue

### DIFF
--- a/src/hooks/useScrollToTop/index.ts
+++ b/src/hooks/useScrollToTop/index.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+import { useLocation } from "wouter";
+
+const useScrollToTop = (): void => {
+  const [pathname] = useLocation();
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+};
+
+export { useScrollToTop };

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,9 +2,11 @@ import type { FC } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
 import { Route, Switch } from "wouter";
 import { TopPage, ComingSoonPage, SponsorPage } from "./pages";
+import { useScrollToTop } from "./hooks/useScrollToTop";
 
 const Router: FC = () => {
   useRegisterSW();
+  useScrollToTop();
   return (
     <Switch>
       <Route path="/" component={TopPage} />


### PR DESCRIPTION
# 📝 what

- 画面遷移時のスクロールの位置が記憶される問題を解決した

# ✅ check

- [x] このリポジトリの[ルール](https://github.com/suzuka-kosen-festa/2022-HP/wiki/%E3%83%AA%E3%83%9D%E3%82%B8%E3%83%88%E3%83%AA%E3%81%AE%E3%83%AB%E3%83%BC%E3%83%AB)に則っているか
- [x] テストを書いた or もう書いてある or 書く必要のない修正
- [x] 動作検証をした

# ℹ️ issue

ref #332 
